### PR TITLE
Simple fix to addAwesomeIcon:beforeTitle: when title is nil

### DIFF
--- a/BButton/BButton.m
+++ b/BButton/BButton.m
@@ -61,7 +61,6 @@
 {
     self.backgroundColor = [UIColor clearColor];
     self.titleLabel.shadowOffset = CGSizeMake(0.0f, -1.0f);
-    self.titleLabel.font = [UIFont boldSystemFontOfSize:17.0f];
     self.shouldShowDisabled = NO;
     [self setType:BButtonTypeDefault];
 }

--- a/BButton/BButton.m
+++ b/BButton/BButton.m
@@ -103,6 +103,7 @@
     self = [super initWithFrame:frame];
     if(self) {
         [self setup];
+        self.titleLabel.font = [UIFont boldSystemFontOfSize:17.0f];
     }
     return self;
 }

--- a/BButton/BButton.m
+++ b/BButton/BButton.m
@@ -217,7 +217,7 @@
     
     NSString *title = [NSString stringWithFormat:@"%@", iconString];
     
-    if(![self.titleLabel.text isEmpty]) {
+    if(self.titleLabel.text && ![self.titleLabel.text isEmpty]) {
         if(before)
             title = [title stringByAppendingFormat:@" %@", self.titleLabel.text];
         else


### PR DESCRIPTION
If button title is nil, calling addAwesomeIcon:beforeTitle: would make
button title appear as '<icon> (null)'
